### PR TITLE
Add systick and delay functionality

### DIFF
--- a/examples/blinky-delay.rs
+++ b/examples/blinky-delay.rs
@@ -1,0 +1,34 @@
+#![feature(asm)]
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use riscv_rt::entry;
+use gd32vf103_hal as hal;
+use hal::prelude::*;
+use hal::pac as pac;
+use hal::delay;
+use hal::systick::Systick;
+use embedded_hal::blocking::delay::DelayMs;
+
+#[entry]
+fn main() -> !
+{
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcu = dp.RCU.constrain();
+
+    let mut gpioa = dp.GPIOA.split(&mut rcu.apb2);
+    let mut pa1 = gpioa.pa1.into_push_pull_output(&mut gpioa.ctl0)
+        .lock(&mut gpioa.lock);
+    gpioa.lock.freeze();
+
+    let clocks = rcu.clocks;
+    let ctimer = dp.CTIMER;
+    let mut delay = delay::Delay::new(clocks, ctimer);
+    loop {
+        pa1.toggle().unwrap();
+        delay.delay_ms(1000 as u32);
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,33 @@
+//! Delay
+use embedded_hal::blocking::delay::{DelayMs};
+use crate::rcu::Clocks;
+use crate::systick::Systick;
+use crate::time::*;
+use gd32vf103_pac::SYSTICK;
+/// Hardware timers
+pub struct Delay{
+    syst: SYSTICK,
+    clock_frequency : Hertz,
+}
+
+
+impl Delay {
+    pub fn new(clocks: Clocks, syst: SYSTICK) -> Self 
+    {
+        Delay {
+            syst: syst,
+            clock_frequency: clocks.ck_ahb(),
+        }
+    }
+}
+
+impl <T: Into<u32>> DelayMs<T> for Delay {
+    // This doesn't wait for a systick tick, so may be off by a few ns. Sorry
+    fn delay_ms(&mut self, ms: T) {
+        let count : u32= (ms.into() * self.clock_frequency.0 / 1000 / (2));
+        let tmp : u64 = Systick::get_systick(&self.syst);
+        let end = tmp + count as u64;
+        while Systick::get_systick(&self.syst) < end{
+        }
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -3,19 +3,19 @@ use embedded_hal::blocking::delay::{DelayMs};
 use crate::rcu::Clocks;
 use crate::systick::Systick;
 use crate::time::*;
-use gd32vf103_pac::SYSTICK;
+use gd32vf103_pac::CTIMER;
 /// Hardware timers
 pub struct Delay{
-    syst: SYSTICK,
+    ctimer: CTIMER,
     clock_frequency : Hertz,
 }
 
 
 impl Delay {
-    pub fn new(clocks: Clocks, syst: SYSTICK) -> Self 
+    pub fn new(clocks: Clocks, ctimer: CTIMER) -> Self 
     {
         Delay {
-            syst: syst,
+            ctimer: ctimer,
             clock_frequency: clocks.ck_ahb(),
         }
     }
@@ -23,11 +23,14 @@ impl Delay {
 
 impl <T: Into<u32>> DelayMs<T> for Delay {
     // This doesn't wait for a systick tick, so may be off by a few ns. Sorry
+    // The divide by two may be incorrect for other dividors. It should be 8
+    // according to the clock diagram, but 2 is accurate. I suspect
+    // this will need to change with further documentation updates.
     fn delay_ms(&mut self, ms: T) {
         let count : u32= (ms.into() * self.clock_frequency.0 / 1000 / (2));
-        let tmp : u64 = Systick::get_systick(&self.syst);
+        let tmp : u64 = Systick::get_systick(&self.ctimer);
         let end = tmp + count as u64;
-        while Systick::get_systick(&self.syst) < end{
+        while Systick::get_systick(&self.ctimer) < end{
         }
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -421,7 +421,7 @@ $(
 
     impl<MODE> $PXi<MODE>
     where
-        MODE: Active,
+    MODE: Active,
     {
         /// Configures the pin to serve as an analog input pin.
         pub fn into_analog(self, $ctl: &mut $CTL) -> $PXi<Analog> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -421,7 +421,7 @@ $(
 
     impl<MODE> $PXi<MODE>
     where
-    MODE: Active,
+        MODE: Active,
     {
         /// Configures the pin to serve as an analog input pin.
         pub fn into_analog(self, $ctl: &mut $CTL) -> $PXi<Analog> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub mod rcu;
 pub mod spi;
 pub mod time;
 pub mod timer;
+pub mod delay;
+pub mod systick;
 
 /// Prelude
 pub mod prelude {

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -1,0 +1,23 @@
+//! Timers
+
+use gd32vf103_pac::SYSTICK;
+// Somehow, weneed totake in theclocks modle so we know howfast theAHB clock is going. 
+// Things we know about the systick peripheral:
+//
+/// Hardware timers
+
+pub struct Systick{
+}
+impl Systick {
+    pub fn get_systick(syst: &SYSTICK) -> u64
+    {
+        let hi : u32 = syst.systick1.read().bits();
+        let lo : u32 = syst.systick0.read().bits();
+        if hi == syst.systick1.read().bits(){
+            return (hi as u64) << 32 | (lo as u64);
+        } else {
+            return (syst.systick1.read().bits() as u64) << 32 | (syst.systick0.read().bits() as u64);
+
+        }
+    }
+}

--- a/src/systick.rs
+++ b/src/systick.rs
@@ -1,22 +1,24 @@
 //! Timers
 
-use gd32vf103_pac::SYSTICK;
-// Somehow, weneed totake in theclocks modle so we know howfast theAHB clock is going. 
-// Things we know about the systick peripheral:
-//
-/// Hardware timers
+use gd32vf103_pac::CTIMER;
+// This right now just gets the systick register, system timer, or mtime. 
+// I believe system timer is the correct name, as the documentation seems to
+// imply mtimer is instruction count, while the system timer increments on
+// clock pulses.
+/// CTIMER
 
 pub struct Systick{
 }
 impl Systick {
-    pub fn get_systick(syst: &SYSTICK) -> u64
+    pub fn get_systick(ctimer: &CTIMER) -> u64
     {
-        let hi : u32 = syst.systick1.read().bits();
-        let lo : u32 = syst.systick0.read().bits();
-        if hi == syst.systick1.read().bits(){
+        // Hi is systick1
+        let hi : u32 = ctimer.mtime_hi.read().bits();
+        let lo : u32 = ctimer.mtime_lo.read().bits();
+        if hi == ctimer.mtime_hi.read().bits(){
             return (hi as u64) << 32 | (lo as u64);
         } else {
-            return (syst.systick1.read().bits() as u64) << 32 | (syst.systick0.read().bits() as u64);
+            return (ctimer.mtime_hi.read().bits() as u64) << 32 | (ctimer.mtime_lo.read().bits() as u64);
 
         }
     }


### PR DESCRIPTION
This implements a delay milliseconds function, and the HAL for the systick peripheral. 

It is not complete yet. It is missing:
mtimer compare register functionality
Delay for us, s, etc.
I believe the delay_ms function needs some work to make more accepting of other types. 

I've tested this and it works on my nano, however  I did not test different clocking speeds yet. 