### PR TITLE
Delay multiplication overflow

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -32,7 +32,7 @@ impl<T: Into<u32>> DelayMs<T> for Delay {
     // according to the clock diagram, but 2 is accurate. I suspect
     // this will need to change with further documentation updates.
     fn delay_ms(&mut self, ms: T) {
-        let count: u32 = ms.into() * self.clock_frequency.0 / 1000 / (2);
+        let count: u32 = ms.into() * (self.clock_frequency.0 / 1000 / 2);
         // todo: avoid using u64 values in this function
         let tmp: u64 = self.ctimer.get_value();
         let end = tmp + count as u64;


### PR DESCRIPTION
I'm coming from https://github.com/martindisch/gd32vf103-demo/issues/1 and noticed a problem with the delay implementation after trying it as you suggested.

Using a delay of 1000 ms resulted in a panic. I tried other values and found out that 537 and higher values fail, while 536 and below work. Because I have trouble with my debugger and can't get semihosting to work, it was pretty hard to exactly get to the bottom of it, but the fact that the panic didn't happen in release mode gave me the final hint I needed to figure it out.

By first multiplying the number of milliseconds with the clock frequency (which is often a large number, e.g. 8000000) before dividing it further, it was easy to run into an overflow case starting at 537 ms, as 537 * 8000000 = 4296000000 which is greater than 2^32 = 4294967296. A possible fix is to only multiply the intended delay with the already divided clock frequency, which allows for larger delays. 
This only shifts the problem though, the maximum delay is now 1073741 ms assuming a clock frequency of 8 MHz. The only way to improve this further is to switch to u64.

Edit: You can see what happened in my case on [this playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2f73f35366d438d5bf746f9a518d6e65). If you run in debug mode it panics, in release mode it overflows and produces a wrong result.