### PR TITLE
Update gd32vf103-pac dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "riscv32imac-unknown-none-elf"
 inline-asm = ["riscv/inline-asm"]
 
 [dependencies]
-gd32vf103-pac = "0.3"
+gd32vf103-pac = "0.4"
 embedded-hal = "1.0.0-alpha.1"
 nb = "1" # todo: remove when `embedded-hal` updated
 riscv = "0.6"


### PR DESCRIPTION
I've updated the dependency on gd32vf103-pac due to a dependency conflict with the bare-metal crate:
```
-cargo build
    Updating crates.io index
error: failed to select a version for `bare-metal`.
    ... required by package `gd32vf103-pac v0.3.0`
    ... which is depended on by `gd32vf103-hal v0.0.5 (/home/users/david/gits/gd32vf103-hal)`
versions that meet the requirements `=0.2.4` are: 0.2.4

all possible versions conflict with previously selected packages.

  previously selected package `bare-metal v0.2.5`
    ... which is depended on by `riscv v0.6.0`
    ... which is depended on by `gd32vf103-hal v0.0.5 (/home/users/david/gits/gd32vf103-hal)`
```

Also, is there any chance you might be able to push a new release up to Crates.io?